### PR TITLE
Small update to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,8 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-compiler-plugin</artifactId>
-	<version>2.3.2</version>
-	<configuration>
-	  <source>1.6</source>
-	  <target>1.6</target>
-	</configuration>
+      	<groupId>org.apache.maven.plugins</groupId>
+      	<artifactId>maven-compiler-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>uk.ac.cam.cl.dtg</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
   </parent>
 
   <groupId>com.github.danieltwagner</groupId>

--- a/src/main/java/com/github/danieltwagner/iso7064/Mod1271_36.java
+++ b/src/main/java/com/github/danieltwagner/iso7064/Mod1271_36.java
@@ -14,7 +14,7 @@ public class Mod1271_36 extends PureSystemCalculator {
 
 	@Override
 	protected String getCharacterSet() {
-		return "0123456789ABCDEFGHIJKLMNOPQRSTUVWXZY";
+		return "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 	}
 
 	@Override


### PR DESCRIPTION
Removes unnecessary definitions for maven-compiler-plugin so that it uses the ones defined in DTG parent pom.

I have also updated the pom to use dtg parent v1.0.3-SNAPSHOT as I am currently using this latest version with some small updates. I have created a [pull request](https://github.com/ucam-cl-dtg/dtg-pom/pull/2) to this latter project so that the updates are included. But this can be reverted back to 1.0.2 if you would prefer.

Also fixes a small typo as seen [here](https://github.com/danieltwagner/iso7064/commit/96f460589c07d144eb014ba1e36ac45c9e769fc4).